### PR TITLE
Simplify transaction building

### DIFF
--- a/app.R
+++ b/app.R
@@ -17,11 +17,11 @@ ui <- fluidPage(
 
   #Use JS
   useShinyjs(),
-  
+
   #Load functions from jscode
   extendShinyjs(text = jscode,
                 functions = c("cert","sendBtn")),
-  
+
   #UI
   titlePanel("Reprex"),
   actionButton("cert","Sign In"),
@@ -48,10 +48,9 @@ server <- function(input, output, session) {
 
   #Observe action button for sign-in
   observeEvent(input$cert, {
-    
+
     #cert function from jscode
-    js$cert()
-    
+    js$cert('Please identify yourself')
   })
 
   #Observe action button for sendBtn
@@ -62,18 +61,12 @@ server <- function(input, output, session) {
       data.frame(
         to= input$to,
         value= input$value,
-        data= input$data
+        data= input$data,
+        comment= "optional clause comment"
       )
-    
-    #Send transaction to JS
-    session$sendCustomMessage(type='myCallbackHandler', jsonlite::toJSON(df))
-    
-    #Send Comments to JS
-    session$sendCustomMessage(type='myCallbackHandler_comments', "Reprex")
-    
-    # Fire Wallet
-    js$sendBtn()
-    
+
+    # send transaction
+    js$sendBtn(jsonlite::toJSON(df))
   })
 
 }

--- a/jscode.R
+++ b/jscode.R
@@ -10,57 +10,34 @@ document.addEventListener('DOMContentLoaded', function () {
     network: 'main'
   })
 
-  var address = '';
+  let address = '';
 
-  shinyjs.cert = function () {
+  shinyjs.cert = function ([reason = null]) {
     connex.vendor.sign('cert', {
       purpose: 'agreement',
       payload: {
         type: 'text',
-        content: 'cert'
+        content: reason || 'Identification'
       }
     })
       .request()
-      .then((r) => {
-        address = r.annex.signer
-        var userAddress = address.toLowerCase();
-        document.getElementById('cert').innerText = 'Signed In';
-        Shiny.setInputValue('r_address',address);
+      .then((cert) => {
+        address = cert.annex.signer
       })
-      .catch((e) => console.log('error:' + e.message));
+      .catch((err) => {
+        console.log('error:' + err.message)
+        address = ''
+      })
+      .finally(() => {
+        document.getElementById('cert').innerText = address ? `Signed as ${address}` : 'Sign In'
+      })
   };
 
-  // Set blank global variable for Shiny event to hook to
 
-  var clauses = '';
-  var comments = '';
-
-  Shiny.addCustomMessageHandler('myCallbackHandler',
-    function(tx_clauses) {
-      // Set global variable to callback handler from Shiny Element
-      clauses = tx_clauses;
-      console.log(clauses);
-      return clauses;
-  });
-
-  Shiny.addCustomMessageHandler('myCallbackHandler_comments',
-    function(tx_comments) {
-      // Set global variable to callback handler from Shiny Element
-      comments = tx_comments;
-      console.log(comments);
-      return comments;
-  });
-
-
- shinyjs.sendBtn = function () {
-
-    connex.vendor.sign('tx',
-
-      clauses
-
-      )
+ shinyjs.sendBtn = function ([clauses = [], comment = '']) {
+    connex.vendor.sign('tx', clauses)
       .link('https://connex.vecha.in/{txid}') // User will be back to the app by the url https://connex.vecha.in/0xffff....
-      .comment(comments)
+      .comment(comment)
       .request()
       .then(result => {
         console.log(result)


### PR DESCRIPTION
The transaction building was modified to:

- pass clauses as argument to the send function
- optionally pass a comment for each clause as attribute, shown in the clause inspection
- optionally pass a transaction comment shown to the user during signing

For the signing I've just added an error handling to reset address & text if a previous successful sign in is tried again and fails.

Question:

- I wonder how can you return data from a function to R? This would simplify the identification, also the transaction id could be returned (or an error)